### PR TITLE
Cache the GOP in media MTX

### DIFF
--- a/apidocs/openapi.yaml
+++ b/apidocs/openapi.yaml
@@ -71,6 +71,8 @@ components:
           type: boolean
         runOnDisconnect:
           type: string
+        gopCache:
+          type: boolean
 
         # Authentication
         authMethod:

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -169,6 +169,7 @@ type Conf struct {
 	RunOnConnect        string          `json:"runOnConnect"`
 	RunOnConnectRestart bool            `json:"runOnConnectRestart"`
 	RunOnDisconnect     string          `json:"runOnDisconnect"`
+	GopCache            bool            `json:"gopCache"`
 
 	// Authentication
 	AuthMethod                AuthMethod                  `json:"authMethod"`

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -347,6 +347,7 @@ func (p *Core) createResources(initial bool) error {
 			pathConfs:         p.conf.Paths,
 			externalCmdPool:   p.externalCmdPool,
 			parent:            p,
+			gopCache:          p.conf.GopCache,
 		}
 		p.pathManager.initialize()
 

--- a/internal/core/path.go
+++ b/internal/core/path.go
@@ -77,6 +77,7 @@ type path struct {
 	wg                *sync.WaitGroup
 	externalCmdPool   *externalcmd.Pool
 	parent            pathParent
+	gopCache          bool
 
 	ctx                            context.Context
 	ctxCancel                      func()
@@ -716,6 +717,7 @@ func (pa *path) setReady(desc *description.Session, allocateEncoder bool) error 
 		desc,
 		allocateEncoder,
 		logger.NewLimitedLogger(pa.source),
+		pa.gopCache,
 	)
 	if err != nil {
 		return err

--- a/internal/core/path_manager.go
+++ b/internal/core/path_manager.go
@@ -59,6 +59,7 @@ type pathManager struct {
 	pathConfs         map[string]*conf.Path
 	externalCmdPool   *externalcmd.Pool
 	parent            pathManagerParent
+	gopCache          bool
 
 	ctx         context.Context
 	ctxCancel   func()
@@ -352,6 +353,7 @@ func (pm *pathManager) createPath(
 		wg:                &pm.wg,
 		externalCmdPool:   pm.externalCmdPool,
 		parent:            pm,
+		gopCache:          pm.gopCache,
 	}
 	pa.initialize()
 

--- a/internal/protocols/hls/from_stream_test.go
+++ b/internal/protocols/hls/from_stream_test.go
@@ -23,6 +23,7 @@ func TestFromStreamNoSupportedCodecs(t *testing.T) {
 		}}},
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 
@@ -56,6 +57,7 @@ func TestFromStreamSkipUnsupportedTracks(t *testing.T) {
 		}},
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 

--- a/internal/protocols/mpegts/from_stream_test.go
+++ b/internal/protocols/mpegts/from_stream_test.go
@@ -22,6 +22,7 @@ func TestFromStreamNoSupportedCodecs(t *testing.T) {
 		}}},
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 
@@ -49,6 +50,7 @@ func TestFromStreamSkipUnsupportedTracks(t *testing.T) {
 		}},
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 

--- a/internal/protocols/rtmp/from_stream_test.go
+++ b/internal/protocols/rtmp/from_stream_test.go
@@ -25,6 +25,7 @@ func TestFromStreamNoSupportedCodecs(t *testing.T) {
 		}}},
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 
@@ -56,6 +57,7 @@ func TestFromStreamSkipUnsupportedTracks(t *testing.T) {
 		}},
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 

--- a/internal/protocols/webrtc/from_stream_test.go
+++ b/internal/protocols/webrtc/from_stream_test.go
@@ -22,6 +22,7 @@ func TestFromStreamNoSupportedCodecs(t *testing.T) {
 		}}},
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 
@@ -49,6 +50,7 @@ func TestFromStreamSkipUnsupportedTracks(t *testing.T) {
 		}},
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 
@@ -84,6 +86,7 @@ func TestFromStream(t *testing.T) {
 				},
 				false,
 				test.NilLogger,
+				false,
 			)
 			require.NoError(t, err)
 			defer stream.Close()

--- a/internal/recorder/recorder_test.go
+++ b/internal/recorder/recorder_test.go
@@ -130,6 +130,7 @@ func TestRecorder(t *testing.T) {
 				desc,
 				true,
 				test.NilLogger,
+				false,
 			)
 			require.NoError(t, err)
 			defer stream.Close()
@@ -343,6 +344,7 @@ func TestRecorderFMP4NegativeDTS(t *testing.T) {
 		desc,
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 	defer stream.Close()
@@ -430,6 +432,7 @@ func TestRecorderSkipTracksPartial(t *testing.T) {
 				desc,
 				true,
 				test.NilLogger,
+				false,
 			)
 			require.NoError(t, err)
 			defer stream.Close()
@@ -490,6 +493,7 @@ func TestRecorderSkipTracksFull(t *testing.T) {
 				desc,
 				true,
 				test.NilLogger,
+				false,
 			)
 			require.NoError(t, err)
 			defer stream.Close()

--- a/internal/servers/hls/server_test.go
+++ b/internal/servers/hls/server_test.go
@@ -160,6 +160,7 @@ func TestServerRead(t *testing.T) {
 			desc,
 			true,
 			test.NilLogger,
+			false,
 		)
 		require.NoError(t, err)
 
@@ -259,6 +260,7 @@ func TestServerRead(t *testing.T) {
 			desc,
 			true,
 			test.NilLogger,
+			false,
 		)
 		require.NoError(t, err)
 
@@ -363,6 +365,7 @@ func TestDirectory(t *testing.T) {
 		desc,
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 

--- a/internal/servers/rtmp/server_test.go
+++ b/internal/servers/rtmp/server_test.go
@@ -45,6 +45,7 @@ func (p *dummyPath) StartPublisher(req defs.PathStartPublisherReq) (*stream.Stre
 		req.Desc,
 		true,
 		test.NilLogger,
+		false,
 	)
 	if err != nil {
 		return nil, err
@@ -200,6 +201,7 @@ func TestServerRead(t *testing.T) {
 				desc,
 				true,
 				test.NilLogger,
+				false,
 			)
 			require.NoError(t, err)
 

--- a/internal/servers/rtsp/server_test.go
+++ b/internal/servers/rtsp/server_test.go
@@ -45,6 +45,7 @@ func (p *dummyPath) StartPublisher(req defs.PathStartPublisherReq) (*stream.Stre
 		req.Desc,
 		true,
 		test.NilLogger,
+		false,
 	)
 	if err != nil {
 		return nil, err
@@ -169,6 +170,7 @@ func TestServerRead(t *testing.T) {
 		desc,
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 

--- a/internal/servers/srt/server_test.go
+++ b/internal/servers/srt/server_test.go
@@ -42,6 +42,7 @@ func (p *dummyPath) StartPublisher(req defs.PathStartPublisherReq) (*stream.Stre
 		req.Desc,
 		true,
 		test.NilLogger,
+		false,
 	)
 	if err != nil {
 		return nil, err
@@ -171,6 +172,7 @@ func TestServerRead(t *testing.T) {
 		desc,
 		true,
 		test.NilLogger,
+		false,
 	)
 	require.NoError(t, err)
 

--- a/internal/stream/stream_format.go
+++ b/internal/stream/stream_format.go
@@ -6,11 +6,17 @@ import (
 
 	"github.com/bluenviron/gortsplib/v4/pkg/description"
 	"github.com/bluenviron/gortsplib/v4/pkg/format"
+	"github.com/bluenviron/mediacommon/pkg/codecs/h264"
+	"github.com/bluenviron/mediacommon/pkg/codecs/h265"
 	"github.com/pion/rtp"
 
 	"github.com/bluenviron/mediamtx/internal/formatprocessor"
 	"github.com/bluenviron/mediamtx/internal/logger"
 	"github.com/bluenviron/mediamtx/internal/unit"
+)
+
+const (
+	maxCachedGOPSize int = 512
 )
 
 func unitSize(u unit.Unit) uint64 {
@@ -19,6 +25,26 @@ func unitSize(u unit.Unit) uint64 {
 		n += uint64(pkt.MarshalSize())
 	}
 	return n
+}
+
+func isKeyFrame(u unit.Unit) bool {
+	switch tunit := u.(type) {
+	case *unit.H264:
+		return h264.IDRPresent(tunit.AU)
+	case *unit.H265:
+		return h265.IsRandomAccess(tunit.AU)
+	}
+	return false
+}
+
+func isEmptyAU(u unit.Unit) bool {
+	switch tunit := u.(type) {
+	case *unit.H264:
+		return len(tunit.AU) == 0
+	case *unit.H265:
+		return len(tunit.AU) == 0
+	}
+	return true
 }
 
 type streamFormat struct {
@@ -30,6 +56,7 @@ type streamFormat struct {
 	proc           formatprocessor.Processor
 	pausedReaders  map[*streamReader]ReadFunc
 	runningReaders map[*streamReader]ReadFunc
+	gopCache       bool
 }
 
 func (sf *streamFormat) initialize() error {
@@ -78,7 +105,7 @@ func (sf *streamFormat) writeRTPPacket(
 	ntp time.Time,
 	pts int64,
 ) {
-	hasNonRTSPReaders := len(sf.pausedReaders) > 0 || len(sf.runningReaders) > 0
+	hasNonRTSPReaders := len(sf.pausedReaders) > 0 || len(sf.runningReaders) > 0 || sf.gopCache
 
 	u, err := sf.proc.ProcessRTPPacket(pkt, ntp, pts, hasNonRTSPReaders)
 	if err != nil {
@@ -93,6 +120,32 @@ func (sf *streamFormat) writeUnitInner(s *Stream, medi *description.Media, u uni
 	size := unitSize(u)
 
 	atomic.AddUint64(s.bytesReceived, size)
+
+	if sf.gopCache && medi.Type == description.MediaTypeVideo {
+		if isKeyFrame(u) {
+			if s.CachedUnits == nil {
+				// Initialize the cache and enable caching
+				s.CachedUnits = make([]unit.Unit, 0, maxCachedGOPSize)
+			} else {
+				// Keep the last packets that were used to generate the key frame.
+				// This is to send a full key frame in the RTSP stream.
+				i := len(s.CachedUnits)
+				for ; i > 0; i-- {
+					if !isEmptyAU(s.CachedUnits[i-1]) {
+						break
+					}
+				}
+				s.CachedUnits = s.CachedUnits[i:]
+			}
+		}
+		if s.CachedUnits != nil {
+			s.CachedUnits = append(s.CachedUnits, u)
+		}
+		l := len(s.CachedUnits)
+		if l > maxCachedGOPSize {
+			s.CachedUnits = s.CachedUnits[l-maxCachedGOPSize:]
+		}
+	}
 
 	if s.rtspStream != nil {
 		for _, pkt := range u.GetRTPPackets() {

--- a/internal/stream/stream_media.go
+++ b/internal/stream/stream_media.go
@@ -15,6 +15,7 @@ func newStreamMedia(udpMaxPayloadSize int,
 	medi *description.Media,
 	generateRTPPackets bool,
 	decodeErrLogger logger.Writer,
+	gopCache bool,
 ) (*streamMedia, error) {
 	sm := &streamMedia{
 		formats: make(map[format.Format]*streamFormat),
@@ -26,6 +27,7 @@ func newStreamMedia(udpMaxPayloadSize int,
 			format:             forma,
 			generateRTPPackets: generateRTPPackets,
 			decodeErrLogger:    decodeErrLogger,
+			gopCache:           gopCache,
 		}
 		err := sf.initialize()
 		if err != nil {

--- a/internal/test/medias.go
+++ b/internal/test/medias.go
@@ -8,6 +8,9 @@ import (
 // MediaH264 is a dummy H264 media.
 var MediaH264 = UniqueMediaH264()
 
+// MediaH265 is a dummy H265 media.
+var MediaH265 = UniqueMediaH265()
+
 // MediaMPEG4Audio is a dummy MPEG-4 audio media.
 var MediaMPEG4Audio = UniqueMediaMPEG4Audio()
 
@@ -16,6 +19,14 @@ func UniqueMediaH264() *description.Media {
 	return &description.Media{
 		Type:    description.MediaTypeVideo,
 		Formats: []format.Format{FormatH264},
+	}
+}
+
+// UniqueMediaH265 is a dummy H265 media.
+func UniqueMediaH265() *description.Media {
+	return &description.Media{
+		Type:    description.MediaTypeVideo,
+		Formats: []format.Format{FormatH265},
 	}
 }
 

--- a/internal/test/source_tester.go
+++ b/internal/test/source_tester.go
@@ -70,6 +70,7 @@ func (t *SourceTester) SetReady(req defs.PathSourceStaticSetReadyReq) defs.PathS
 		req.Desc,
 		req.GenerateRTPPackets,
 		t,
+		false,
 	)
 
 	t.reader = NilLogger

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -23,6 +23,9 @@ writeQueueSize: 512
 # Maximum size of outgoing UDP packets.
 # This can be decreased to avoid fragmentation on networks with a low UDP MTU.
 udpMaxPayloadSize: 1472
+# Enable GOP cache to improve initial playback experience for new clients.
+# Note: will increase memory usage.
+gopCache: false
 
 # Command to run when a client connects to the server.
 # This is terminated with SIGINT when a client disconnects from the server.


### PR DESCRIPTION
This PR introduces Group of Pictures (GOP) caching to MediaMTX, enhancing its performance and reducing latency in streaming scenarios. By caching the last GOP for each stream, new subscribers can immediately receive the latest video data without waiting for the next keyframe, improving the user experience, especially for streams with long keyframe intervals.

### Key Changes
### GOP Caching Implementation:

Added a mechanism to store the most recent GOP for each stream in memory.
Ensured that both video frames and keyframes are stored as part of the cache.
### Configurable Cache Settings:

Introduced a new configuration parameter `gopCache` in `mediamtx.yml` for enabling/disabling GOP caching.