### PR TITLE
Update session.go

### DIFF
--- a/internal/servers/rtsp/session.go
+++ b/internal/servers/rtsp/session.go
@@ -272,15 +272,19 @@ func (s *session) onPlay(_ *gortsplib.ServerHandlerOnPlayCtx) (*base.Response, e
 		s.mutex.Unlock()
 
 		if len(s.stream.CachedUnits) > 0 {
-			lastTimestamp := s.stream.CachedUnits[len(s.stream.CachedUnits)-1].GetRTPPackets()[0].Timestamp
-			for _, medi := range s.stream.Desc().Medias {
-				if medi.Type == description.MediaTypeVideo {
-					for _, u := range s.stream.CachedUnits {
-						for _, pkt := range u.GetRTPPackets() {
-							pkt.Timestamp = lastTimestamp
-							err := s.rsession.WritePacketRTP(medi, pkt)
-							if err != nil {
-								break
+			lastCachedUnits := s.stream.CachedUnits[len(s.stream.CachedUnits)-1]
+			rtpPackets := lastCachedUnits.GetRTPPackets()
+			if len(rtpPackets) > 0 {
+				lastTimestamp := rtpPackets[0].Timestamp
+				for _, medi := range s.stream.Desc().Medias {
+					if medi.Type == description.MediaTypeVideo {
+						for _, u := range s.stream.CachedUnits {
+							for _, pkt := range u.GetRTPPackets() {
+								pkt.Timestamp = lastTimestamp
+								err := s.rsession.WritePacketRTP(medi, pkt)
+								if err != nil {
+									break
+								}
 							}
 						}
 					}


### PR DESCRIPTION
Fixes:

```
panic: runtime error: index out of range [0] with length 0

goroutine 551 [running]:

http://github.com/bluenviron/mediamtx/internal/servers/rtsp.(*session ).onPlay(0xc0000a8b40, 0xf46cc0?)

/s/internal/servers/rtsp/session.go:275 +0x6d9

http://github.com/bluenviron/mediamtx/internal/servers/rtsp.(*Server ).OnPlay(0x1899ed0?, 0xfa34e0?)

/s/internal/servers/rtsp/server.go:289 +0x2e

http://github.com/bluenviron/gortsplib/v4.(*ServerSession ).handleRequestInner(0xc0000306e0, 0xc000292380, 0xc0039bc3c0)

/go/pkg/mod/github.com/!solink!corp/gortsplib/v4@v4.0.0-20250204185832-227eea17ed07/server_session.go:1159 +0x311c

http://github.com/bluenviron/gortsplib/v4.(*ServerSession ).runInner(0xc0000306e0)

/go/pkg/mod/github.com/!solink!corp/gortsplib/v4@v4.0.0-20250204185832-227eea17ed07/server_session.go:677 +0x335

http://github.com/bluenviron/gortsplib/v4.(*ServerSession ).run(0xc0000306e0)

/go/pkg/mod/github.com/!solink!corp/gortsplib/v4@v4.0.0-20250204185832-227eea17ed07/server_session.go:621 +0x10f

created by http://github.com/bluenviron/gortsplib/v4.(*ServerSession ).initialize in goroutine 11

/go/pkg/mod/github.com/!solink!corp/gortsplib/v4@v4.0.0-20250204185832-227eea17ed07/server_session.go:286 +0x351
```