### PR TITLE
Add timeout to socket.Accept

### DIFF
--- a/internal/staticsources/unix/source.go
+++ b/internal/staticsources/unix/source.go
@@ -36,7 +36,6 @@ func acceptWithContext(ln net.Listener, timeout time.Duration) (net.Conn, error)
 	conn, err := ln.Accept()
 	timer.Stop()
 	return conn, err
-
 }
 
 // Run implements StaticSource.

--- a/internal/staticsources/unix/source.go
+++ b/internal/staticsources/unix/source.go
@@ -28,7 +28,7 @@ func (s *Source) Log(level logger.Level, format string, args ...interface{}) {
 	s.Parent.Log(level, "[unix source] "+format, args...)
 }
 
-func acceptWithContext(ln net.Listener, timeout time.Duration) (net.Conn, error) {
+func acceptWithTimeout(ln net.Listener, timeout time.Duration) (net.Conn, error) {
 	timer := time.AfterFunc(timeout, func() {
 		ln.Close()
 	})
@@ -58,7 +58,7 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 	}
 	defer socket.Close()
 
-	conn, err := acceptWithContext(socket, 10*time.Second)
+	conn, err := acceptWithTimeout(socket, 10*time.Second)
 	if err != nil {
 		return err
 	}

--- a/internal/staticsources/unix/source.go
+++ b/internal/staticsources/unix/source.go
@@ -36,12 +36,16 @@ func acceptWithContext(ctx context.Context, ln net.Listener) (net.Conn, error) {
 	go func() {
 		conn, err := ln.Accept()
 		if err != nil {
-			// Check if channel is closed before sending
-			_, ok := <-errChan
-			if !ok {
-				return
+			select {
+			case _, ok := <-errChan:
+				if !ok {
+					return
+				} else {
+					errChan <- err
+				}
+			default:
+				errChan <- err
 			}
-			errChan <- err
 		} else {
 			connChan <- conn
 		}

--- a/internal/staticsources/unix/source.go
+++ b/internal/staticsources/unix/source.go
@@ -32,7 +32,7 @@ func acceptWithContext(ln net.Listener, timeout time.Duration) (net.Conn, error)
 	timer := time.AfterFunc(timeout, func() {
 		ln.Close()
 	})
-        defer timer.Stop()
+	defer timer.Stop()
 	return ln.Accept()
 }
 

--- a/internal/staticsources/unix/source.go
+++ b/internal/staticsources/unix/source.go
@@ -28,8 +28,8 @@ func (s *Source) Log(level logger.Level, format string, args ...interface{}) {
 	s.Parent.Log(level, "[unix source] "+format, args...)
 }
 
-func acceptWithContext(ln net.Listener) (net.Conn, error) {
-	timer := time.AfterFunc(time.Duration(10)*time.Second, func() {
+func acceptWithContext(ln net.Listener, timeout time.Duration) (net.Conn, error) {
+	timer := time.AfterFunc(timeout, func() {
 		ln.Close()
 	})
 
@@ -61,7 +61,7 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 	}
 	defer socket.Close()
 
-	conn, err := acceptWithContext(socket)
+	conn, err := acceptWithContext(socket, time.Duration(10)*time.Second)
 	if err != nil {
 		return err
 	}

--- a/internal/staticsources/unix/source.go
+++ b/internal/staticsources/unix/source.go
@@ -32,10 +32,8 @@ func acceptWithContext(ln net.Listener, timeout time.Duration) (net.Conn, error)
 	timer := time.AfterFunc(timeout, func() {
 		ln.Close()
 	})
-
-	conn, err := ln.Accept()
-	timer.Stop()
-	return conn, err
+        defer timer.Stop()
+	return ln.Accept()
 }
 
 // Run implements StaticSource.

--- a/internal/staticsources/unix/source.go
+++ b/internal/staticsources/unix/source.go
@@ -60,7 +60,7 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 	}
 	defer socket.Close()
 
-	conn, err := acceptWithContext(socket, time.Duration(10)*time.Second)
+	conn, err := acceptWithContext(socket, 10*time.Second)
 	if err != nil {
 		return err
 	}

--- a/internal/staticsources/unix/source_test.go
+++ b/internal/staticsources/unix/source_test.go
@@ -27,7 +27,7 @@ func TestSource(t *testing.T) {
 	)
 	defer te.Close()
 
-	time.Sleep(250 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 
 	conn, err := net.Dial("unix", "/tmp/mediamtx-test.sock")
 	require.NoError(t, err)

--- a/internal/staticsources/unix/source_test.go
+++ b/internal/staticsources/unix/source_test.go
@@ -27,7 +27,7 @@ func TestSource(t *testing.T) {
 	)
 	defer te.Close()
 
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(250 * time.Millisecond)
 
 	conn, err := net.Dial("unix", "/tmp/mediamtx-test.sock")
 	require.NoError(t, err)


### PR DESCRIPTION
Without a timeout to socket.Accept, it will wait indefinitely until it gets a connection.

If the underline socket becomes invalid or is deleted, connections will effectively become impossible.