### PR TITLE
fix: increase Accept timeout

### DIFF
--- a/internal/staticsources/unix/source.go
+++ b/internal/staticsources/unix/source.go
@@ -58,7 +58,7 @@ func (s *Source) Run(params defs.StaticSourceRunParams) error {
 	}
 	defer socket.Close()
 
-	conn, err := acceptWithTimeout(socket, 10*time.Second)
+	conn, err := acceptWithTimeout(socket, 5*time.Minute)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### **Increase Net Listener Accept Timeout from 10s to 5m**

#### **Summary**

This PR increases the network listener `Accept` timeout from **10 seconds** to **5 minutes**.

#### **Rationale**

The previous Accept timeout was effectively infinite, and it worked well on all systems, except one.
The connecting client will try in an exponential backoff pattern, and the server will accept the connection when it is ready.
I am worried that if the client connects every 30s, and the server resets every 10s, there might be a time when they never sync up.

Seems like increasing the timeout significantly is a good solution.