### PR TITLE
fix: [SL-14857] - Security - Unsafe Quoting - Core Apps

### DIFF
--- a/internal/protocols/whip/link_header.go
+++ b/internal/protocols/whip/link_header.go
@@ -4,14 +4,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/pion/webrtc/v4"
 )
 
 func quoteCredential(v string) string {
-	b, _ := json.Marshal(v)
-	s := string(b)
-	return s[1 : len(s)-1]
+	escaped := strings.ReplaceAll(v, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	return escaped
 }
 
 func unquoteCredential(v string) string {

--- a/internal/protocols/whip/link_header_test.go
+++ b/internal/protocols/whip/link_header_test.go
@@ -30,6 +30,20 @@ var linkHeaderCases = []struct {
 			},
 		},
 	},
+	{
+		"credential with embedded quotes",
+		[]string{
+			`<turns:turn.example.com>; rel="ice-server"; username="user"; ` +
+				`credential="pass\"word"; credential-type="password"`,
+		},
+		[]webrtc.ICEServer{
+			{
+				URLs:       []string{"turns:turn.example.com"},
+				Username:   "user",
+				Credential: `pass"word`,
+			},
+		},
+	},
 }
 
 func TestLinkHeaderUnmarshal(t *testing.T) {


### PR DESCRIPTION
# Description
- Use the simple strings replaceAll instead of the poorly secured quoteCredential from the json lib
- Added unit test for it

# Jira
https://solink.atlassian.net/browse/SL-14857

# Testing:

1. go test -v -run TestLinkHeader ./internal/protocols/whip/ — all link header roundtrip tests pass, including new test case for credentials with embedded double quotes
2. Pre-existing test failures in other packages are unrelated to this change (same failure on main before the fix)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to WHIP ICE link-header encoding with added test coverage; no auth or data-model changes beyond safer string escaping.
> 
> **Overview**
> **WHIP link header marshaling** now escapes TURN username and password values with explicit backslash and quote replacement instead of `json.Marshal` + stripping outer quotes on `quoteCredential`.
> 
> A new round-trip test covers credentials that contain embedded `"` characters so marshal output matches what `LinkHeaderUnmarshal` expects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeac9bb20855bfe00960a7ef7a13df1959f78294. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->